### PR TITLE
Fix    mb_convert_encoding(): Illegal character encoding specified

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -291,6 +291,8 @@ class Message
 
     private function convertEncoding($str, $from = "ISO-8859-2", $to = "UTF-8")
     {
+        if(!$from)
+            return mb_convert_encoding($str, $to);
         return mb_convert_encoding($str, $to, $from);
     }
 


### PR DESCRIPTION
…exception when try to convert encoding of message body with unknown source encoding.
