### PR TITLE
Fix empty partNumber in imap_fetchbody

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -226,7 +226,7 @@ class Message
                     break;
             }
 
-            $content = imap_fetchbody($this->client->connection, $this->message_no, $partNumber, FT_UID);
+            $content = imap_fetchbody($this->client->connection, $this->message_no, ($partNumber) ? $partNumber : 1, FT_UID);
 
             $attachment = new \stdClass;
             $attachment->type = $type;


### PR DESCRIPTION
I had trouble with messages, that only contained an attachment in their body. The value for `$partNumber`was not set in `fetchStructure()` thus `imap_fetchbody()` returned `null`. The edited line fixes the issue and should, according to my tests, not have any side effects on messages with more content in the body.
