### PR TITLE
ServiceProvider namespace changed after release 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require zalazdi/laravel-imap
 
 3. Add this line to `config\app.php` into providers section:
 ```
-Zalazdi\LaravelImap\LaravelImapServiceProvider::class,
+Zalazdi\LaravelImap\Providers\LaravelServiceProvider::class, 
 ```
 
 ## Usage


### PR DESCRIPTION
I had some problems after `composer update`. Reason was the release of Version 1.0.4 where the provider has been moved.

Zalazdi\LaravelImap\LaravelImapServiceProvider::class,
To:
Zalazdi\LaravelImap\Providers\LaravelServiceProvider::class,