### PR TITLE
Require imap extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     ],
     "require": {
         "illuminate/support": "~5.1",
-        "php" : ">=5.3.0"
+        "php" : ">=5.3.0",
+        "ext-imap": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixing `Call to undefined function imap_open` if this extension is not activated by require Composer check.