### PR TITLE
Add getConnection method to Client class

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -306,4 +306,16 @@ class Client
 
         return $address;
     }
+    
+    /**
+    * Get an IMAP stream on success or FALSE on error. 
+    *
+    * @return bool|resource
+    */
+    public function getConnection()
+    {
+        $this->checkConnection();
+        
+        return $this->connection;
+    }
 }


### PR DESCRIPTION
Add method that returns an IMAP stream on success or FALSE on error.
In order to use IMAP stream outside this class.